### PR TITLE
fix the push command break tests and some small lints fixings

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -17,13 +17,11 @@
 from contextlib import contextmanager
 import datetime
 import getpass
-import hashlib
 import json
 import logging
 import os
 import re
 import subprocess
-import sys
 import tempfile
 
 from subprocess import Popen
@@ -69,7 +67,6 @@ def _get_url_from_error(error):
     if error.extra:
         return error.extra[0].get('url')
     return None
-
 
 
 def _check_dev_agreement_and_namespace_statuses(store):

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -667,7 +667,8 @@ class StatusTracker:
         'being_processed': 'Processing...',
         'ready_to_release': 'Ready to release!',
         'need_manual_review': 'Will need manual review...',
-        'processing_delta_application_error': 'Error while processing delta...',
+        'processing_delta_application_error':
+            'Error while processing delta...',
         'processing_error': 'Error while processing...',
     }
 

--- a/snapcraft/tests/test_cache.py
+++ b/snapcraft/tests/test_cache.py
@@ -95,7 +95,6 @@ class SnapCacheTestCase(tests.TestCase):
 
         self.assertEqual('bears', 'doorstops')
 
-
     def test_snap_cache_get_latest(self):
         self.useFixture(fixture_setup.FakeTerminal())
 

--- a/snapcraft/tests/test_commands_push.py
+++ b/snapcraft/tests/test_commands_push.py
@@ -81,9 +81,7 @@ class PushCommandTestCase(tests.TestCase):
             'Revision 9 of \'my-snap-name\' created.',
             self.fake_logger.output)
 
-        mock_upload.assert_called_once_with(
-            'my-snap-name', snap_file, delta_format=None, source_hash=None,
-            target_hash=None, delta_hash=None)
+        mock_upload.assert_called_once_with('my-snap-name', snap_file)
 
     def test_push_without_login_must_raise_exception(self):
         snap_path = os.path.join(
@@ -151,9 +149,7 @@ class PushCommandTestCase(tests.TestCase):
             'Revision 9 of \'my-snap-name\' created.',
             self.fake_logger.output)
 
-        mock_upload.assert_called_once_with(
-            'my-snap-name', snap_file, delta_format=None, source_hash=None,
-            target_hash=None, delta_hash=None)
+        mock_upload.assert_called_once_with('my-snap-name', snap_file)
 
     def test_push_and_release_a_snap(self):
         self.useFixture(fixture_setup.FakeTerminal())
@@ -199,9 +195,7 @@ class PushCommandTestCase(tests.TestCase):
             'Revision 9 of \'my-snap-name\' created.',
             self.fake_logger.output)
 
-        mock_upload.assert_called_once_with(
-            'my-snap-name', snap_file, delta_format=None, source_hash=None,
-            target_hash=None, delta_hash=None)
+        mock_upload.assert_called_once_with('my-snap-name', snap_file)
         mock_release.assert_called_once_with('my-snap-name', 9, ['beta'])
 
     def test_push_and_release_a_snap_to_N_channels(self):
@@ -250,9 +244,7 @@ class PushCommandTestCase(tests.TestCase):
             'Revision 9 of \'my-snap-name\' created.',
             self.fake_logger.output)
 
-        mock_upload.assert_called_once_with(
-            'my-snap-name', snap_file, delta_format=None, source_hash=None,
-            target_hash=None, delta_hash=None)
+        mock_upload.assert_called_once_with('my-snap-name', snap_file)
         mock_release.assert_called_once_with('my-snap-name', 9,
                                              ['edge', 'beta', 'candidate'])
 
@@ -337,9 +329,9 @@ class PushCommandDeltasTestCase(tests.TestCase):
 
         _, kwargs = self.mock_upload.call_args
         if self.enable_deltas:
-            self.assertEqual(kwargs['delta_format'], 'xdelta')
+            self.assertEqual(kwargs.get('delta_format'), 'xdelta')
         else:
-            self.assertIsNone(kwargs['delta_format'])
+            self.assertIsNone(kwargs.get('delta_format'))
 
 
 class PushCommandDeltasWithPruneTestCase(tests.TestCase):


### PR DESCRIPTION
fixed the push command testcases which are normally upload without delta file. they shouldn't pass the extra parameters: delta_format, source_hash, target_hash and delta_hash, or the testcases breaks.

some lints fixings